### PR TITLE
fix(messaging): Correct SacredMesh instantiation

### DIFF
--- a/src/lib/unifiedMessaging/UnifiedMessagingService.ts
+++ b/src/lib/unifiedMessaging/UnifiedMessagingService.ts
@@ -98,7 +98,7 @@ export class UnifiedMessagingService {
       ...config
     };
 
-    this.sacredMesh = SacredMesh.getInstance();
+    this.sacredMesh = new SacredMesh();
     this.messageQueue = new DurableStore('message-queue');
     this.retryQueue = new DurableStore('retry-queue');
 


### PR DESCRIPTION
The UnifiedMessagingService was attempting to instantiate SacredMesh using a singleton `getInstance()` method, which does not exist on the SacredMesh class. This caused a `TypeError` during the service's initialization, preventing the messaging system from working.

This commit corrects the instantiation by using the standard `new SacredMesh()` constructor, which is the intended way to create an instance of the class. This resolves the startup error and allows the UnifiedMessagingService to initialize correctly.