### PR TITLE
Feat: Implement full Codex enhancements and CRUD functionality

### DIFF
--- a/jules-scratch/verify_db_data.mjs
+++ b/jules-scratch/verify_db_data.mjs
@@ -1,0 +1,37 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Credentials from the .env file
+const supabaseUrl = 'https://mikltjgbvxrxndtszorb.supabase.co';
+const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1pa2x0amdidnhyeG5kdHN6b3JiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDM2NDI3MDksImV4cCI6MjA1OTIxODcwOX0.f4QfhZzSZJ92AjCfbkEMrrmzJrWI617H-FyjJKJ8_70';
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function checkData() {
+  console.log('Attempting to fetch data from registry_of_resonance...');
+
+  try {
+    const { data, error, count } = await supabase
+      .from('registry_of_resonance')
+      .select('*', { count: 'exact', head: true }); // Use head:true to only get the count, not the data
+
+    if (error) {
+      console.error('An error occurred while fetching data:', error);
+      return;
+    }
+
+    console.log(`Successfully connected to the database.`);
+    console.log(`Found ${count} entries in the 'registry_of_resonance' table.`);
+
+    if (count > 0) {
+      console.log('This indicates the data is still present in the database.');
+      console.log('The issue is likely with how the data is being fetched or displayed in the UI.');
+    } else {
+      console.log('This indicates the data is NOT present in the database. This points to a data loss issue.');
+    }
+
+  } catch (e) {
+    console.error('A critical error occurred:', e);
+  }
+}
+
+checkData();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import Journal from "./pages/Journal";
 import VideoLibrary from "./pages/VideoLibrary";
 import CollectiveAkashicConstellationPage from "./pages/CollectiveAkashicConstellation";
 import RegistryEntry from "./pages/RegistryEntry";
+import RegistryEntryEdit from "./pages/RegistryEntryEdit";
 import AkashicConstellationPage from "./pages/AkashicConstellation";
 import Guidebook from "./pages/Guidebook";
 import Support from "./pages/Support";
@@ -65,6 +66,7 @@ function App() {
                 <Route path="/videos" element={<VideoLibrary />} />
                 <Route path="/registry" element={<CollectiveAkashicConstellationPage />} />
                 <Route path="/resonance/entries/:id" element={<RegistryEntry />} />
+                <Route path="/registry/:id/edit" element={<RegistryEntryEdit />} />
                 <Route path="/codex" element={<AkashicConstellationPage />} />
                 <Route path="/grove" element={<Grove />} />
                 <Route path="/liberation" element={<Liberation />} />

--- a/src/components/CollectiveAkashicConstellation/CollectiveAkashicConstellation.tsx
+++ b/src/components/CollectiveAkashicConstellation/CollectiveAkashicConstellation.tsx
@@ -209,7 +209,7 @@ export function CollectiveAkashicConstellation() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedEntry, setSelectedEntry] = useState(null);
   const [hoveredEntry, setHoveredEntry] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<'constellation' | 'grid'>('constellation');
+  const [viewMode, setViewMode] = useState<'constellation' | 'grid'>('grid');
   const [activeTab, setActiveTab] = useState('collective');
 
   const handleTabChange = (value: string) => {

--- a/src/components/CollectiveAkashicConstellation/CollectiveAkashicEntryModal.tsx
+++ b/src/components/CollectiveAkashicConstellation/CollectiveAkashicEntryModal.tsx
@@ -35,6 +35,8 @@ interface CollectiveAkashicEntryModalProps {
 export function CollectiveAkashicEntryModal({ isOpen, onClose, onSubmit, initialData }: CollectiveAkashicEntryModalProps) {
   const [formData, setFormData] = useState({
     title: '',
+    author_name: '',
+    author_bio: '',
     content: '',
     entry_type: 'Consciousness Threads',
     access_level: 'Public',
@@ -66,6 +68,8 @@ export function CollectiveAkashicEntryModal({ isOpen, onClose, onSubmit, initial
     if (initialData) {
       setFormData({
         title: initialData.title || '',
+        author_name: initialData.author_name || '',
+        author_bio: initialData.author_bio || '',
         content: initialData.content || '',
         entry_type: initialData.entry_type || 'Consciousness Threads',
         access_level: initialData.access_level || 'Public',
@@ -76,6 +80,8 @@ export function CollectiveAkashicEntryModal({ isOpen, onClose, onSubmit, initial
     } else {
       setFormData({
         title: '',
+        author_name: '',
+        author_bio: '',
         content: '',
         entry_type: 'Consciousness Threads',
         access_level: 'Public',
@@ -166,6 +172,30 @@ export function CollectiveAkashicEntryModal({ isOpen, onClose, onSubmit, initial
               required
               className="bg-background/50"
             />
+          </div>
+
+          {/* Author Details */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="author_name">Author Name</Label>
+              <Input
+                id="author_name"
+                value={formData.author_name}
+                onChange={(e) => setFormData(prev => ({ ...prev, author_name: e.target.value }))}
+                placeholder="Your name or alias"
+                className="bg-background/50"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="author_bio">Author Bio</Label>
+              <Input
+                id="author_bio"
+                value={formData.author_bio}
+                onChange={(e) => setFormData(prev => ({ ...prev, author_bio: e.target.value }))}
+                placeholder="A short bio"
+                className="bg-background/50"
+              />
+            </div>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/pages/RegistryEntryEdit.tsx
+++ b/src/pages/RegistryEntryEdit.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useRegistryOfResonance } from '@/hooks/useRegistryOfResonance';
+import { useAuth } from '@/hooks/useAuth';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { toast } from 'sonner';
+
+// Using the same interface from RegistryEntry page
+interface RegistryEntry {
+  id: string;
+  title: string;
+  content: string;
+  quick_abstract?: string;
+  author_name?: string;
+  author_bio?: string;
+  // ... other fields
+}
+
+export default function RegistryEntryEdit() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const { updateEntry } = useRegistryOfResonance();
+  const [entry, setEntry] = useState<Partial<RegistryEntry>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) {
+      navigate('/registry');
+      return;
+    }
+    // Fetch existing entry data
+    const fetchEntry = async () => {
+      // This is a simplified fetch, ideally the hook would have a getEntryById function
+      const { data, error } = await import('@/integrations/supabase/client')
+        .then(module => module.supabase.from('registry_of_resonance').select('*').eq('id', id).single());
+
+      if (error || !data) {
+        toast.error('Failed to fetch entry for editing.');
+        navigate('/registry');
+      } else {
+        // Security check: only author can edit
+        if (data.user_id !== user?.id) {
+          toast.error("You don't have permission to edit this entry.");
+          navigate(`/resonance/entries/${id}`);
+          return;
+        }
+        setEntry(data);
+      }
+      setLoading(false);
+    };
+    fetchEntry();
+  }, [id, navigate, user]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setEntry(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+
+    const { title, content, author_name, author_bio, quick_abstract } = entry;
+    const success = await updateEntry(id, { title, content, author_name, author_bio, quick_abstract });
+    if (success) {
+      toast.success('Entry updated successfully!');
+      navigate(`/resonance/entries/${id}`);
+    }
+  };
+
+  if (loading) {
+    return <div>Loading editor...</div>;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>Editing Registry Entry</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <label htmlFor="title" className="block text-sm font-medium mb-1">Title</label>
+              <Input id="title" name="title" value={entry.title || ''} onChange={handleChange} />
+            </div>
+            <div>
+              <label htmlFor="author_name" className="block text-sm font-medium mb-1">Author Name</label>
+              <Input id="author_name" name="author_name" value={entry.author_name || ''} onChange={handleChange} />
+            </div>
+            <div>
+              <label htmlFor="author_bio" className="block text-sm font-medium mb-1">Author Bio</label>
+              <Textarea id="author_bio" name="author_bio" value={entry.author_bio || ''} onChange={handleChange} rows={3} />
+            </div>
+             <div>
+              <label htmlFor="quick_abstract" className="block text-sm font-medium mb-1">Quick Abstract</label>
+              <Textarea id="quick_abstract" name="quick_abstract" value={entry.quick_abstract || ''} onChange={handleChange} rows={3} />
+            </div>
+            <div>
+              <label htmlFor="content" className="block text-sm font-medium mb-1">Content (Markdown)</label>
+              <Textarea id="content" name="content" value={entry.content || ''} onChange={handleChange} rows={15} />
+            </div>
+            <div className="flex justify-end gap-4">
+              <Button type="button" variant="outline" onClick={() => navigate(`/resonance/entries/${id}`)}>Cancel</Button>
+              <Button type="submit">Save Changes</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/supabase/migrations/20250826151400_create_user_bookmarks.sql
+++ b/supabase/migrations/20250826151400_create_user_bookmarks.sql
@@ -1,0 +1,38 @@
+-- Migration: Create user_bookmarks table
+-- This table will store a record of which user has bookmarked which registry entry,
+-- enabling a persistent, personal bookmarking feature.
+
+-- Create the user_bookmarks table
+CREATE TABLE public.user_bookmarks (
+    entry_id UUID NOT NULL REFERENCES public.registry_of_resonance(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+    PRIMARY KEY (entry_id, user_id)
+);
+
+-- Add comments for clarity
+COMMENT ON TABLE public.user_bookmarks IS 'Tracks which users have bookmarked which registry entries.';
+COMMENT ON COLUMN public.user_bookmarks.entry_id IS 'The foreign key to the bookmarked registry entry.';
+COMMENT ON COLUMN public.user_bookmarks.user_id IS 'The foreign key to the user who created the bookmark.';
+
+-- Enable Row Level Security
+ALTER TABLE public.user_bookmarks ENABLE ROW LEVEL SECURITY;
+
+-- Add RLS Policies
+-- Users can view their own bookmarks.
+CREATE POLICY "Users can view their own bookmarks"
+ON public.user_bookmarks
+FOR SELECT
+USING (auth.uid() = user_id);
+
+-- Users can create their own bookmarks.
+CREATE POLICY "Users can create their own bookmarks"
+ON public.user_bookmarks
+FOR INSERT
+WITH CHECK (auth.uid() = user_id);
+
+-- Users can delete their own bookmarks.
+CREATE POLICY "Users can delete their own bookmarks"
+ON public.user_bookmarks
+FOR DELETE
+USING (auth.uid() = user_id);


### PR DESCRIPTION
This commit delivers a comprehensive set of enhancements to the Collective Codex feature, transforming it into a more interactive, resonance-driven archive, and restores full CRUD functionality as requested in follow-up feedback.

The following changes have been implemented:

### Database Schema Enhancements:
- Created a new Supabase migration to enhance the `registry_of_resonance` table with `quick_abstract` and `resonance_growth_data` columns.
- Created a new `reflection_notes` table for private, user-specific notes on entries, complete with RLS policies for privacy.
- Created a new `user_bookmarks` table to enable persistent, user-specific bookmarking, also with RLS policies.

### Backend Hook Modifications (`useRegistryOfResonance.tsx`):
- **Interactivity:**
  - Added `addReflectionNote` and `getReflectionNotes` for private notes.
  - Added `exportEntryAsSeed` to download an entry as a JSON packet.
  - Implemented `toggleBookmark` and `getBookmarkStatus` for user-specific bookmarking.
  - Updated `toggleResonance` to track data for the resonance growth chart.
- **Navigation:**
  - Implemented `getNextPreviousEntries` to fetch adjacent entry IDs.
- **CRUD:**
  - Verified that `createEntry`, `updateEntry`, and `deleteEntry` are present and correctly wired up.

### UI & Frontend Implementation:
- **Codex List View (`CollectiveAkashicConstellation.tsx`):**
  - The view now defaults to 'grid' mode as requested.
- **Entry Page (`RegistryEntry.tsx`):**
  - **Interactivity Layer:** The UI has been updated with new "Resonate", "Echo", "Seed", and user-specific "Bookmark" buttons.
  - **CRUD:** Added author-only "Edit" and "Delete" buttons (with confirmation dialog).
  - **Navigation:** The next/previous entry buttons are now functional.
  - **Layout & Hierarchy:** Implemented a new sticky header, a "Quick Abstract" section, and support for styled pull-quotes in Markdown.
  - **Metrics & Community:** Added a `ResonanceChart`, a `TagCloud`, and a tabbed interface for `PublicDiscussion` (with threading) and `ReflectionNotes`.
- **Create/Edit Forms:**
  - Created a new `RegistryEntryEdit.tsx` page and route for editing entries.
  - Added "Author Name" and "Author Bio" fields to both the creation modal and the new edit page.
- **Sharing Modal:**
  - Implemented the `ShareToCircleModal` for the "Echo" button functionality by reusing an existing component.

### Testing & Verification:
- Added a new test file for the `useRegistryOfResonance` hook with tests for the new bookmarking functionality. The test suite passes after fixing several issues with the mocks.
- Frontend verification via Playwright was attempted, but blocked due to a lack of authentication credentials for the development environment. The application code itself is complete, but I was unable to generate a final screenshot of the implemented features in a logged-in state.